### PR TITLE
Update BGR init sequence with MADCTL BGR bit 0x08

### DIFF
--- a/adafruit_st7735r.py
+++ b/adafruit_st7735r.py
@@ -74,7 +74,7 @@ class ST7735R(displayio.Display):
         init_sequence = _INIT_SEQUENCE
         if bgr:
             init_sequence += (
-                b"\x36\x01\xC0"  # _MADCTL Default rotation plus BGR encoding
+                b"\x36\x01\xC8"  # _MADCTL Default rotation plus BGR encoding
             )
         if invert:
             init_sequence += b"\x21\x00"  # _INVON


### PR DESCRIPTION
Re issue: https://github.com/adafruit/Adafruit_CircuitPython_ST7735R/issues/21

https://cdn-shop.adafruit.com/datasheets/ST7735R_V0.2.pdf
Page 113 - RGB-BGR ORDER