### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Usage Example
     display = ST7735R(display_bus, width=128, height=128, colstart=2, rowstart=1)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(128, 128, 1)

--- a/examples/st7735r_128x160_colored_labels.py
+++ b/examples/st7735r_128x160_colored_labels.py
@@ -28,7 +28,7 @@ display = ST7735R(
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(160, 80, 1)
@@ -36,7 +36,7 @@ color_palette = displayio.Palette(1)
 # write some text in each font color, rgb, cmyk
 color_palette[0] = 0x111111  # light grey
 
-text_group_left = displayio.Group(max_size=10, scale=1, x=0, y=6)
+text_group_left = displayio.Group(scale=1, x=0, y=6)
 text_area_red = label.Label(terminalio.FONT, text="RED", color=0xFF0000)
 text_area_green = label.Label(terminalio.FONT, text="\nGREEN", color=0x00FF00)
 text_area_blue = label.Label(terminalio.FONT, text="\n\nBLUE", color=0x0000FF)
@@ -47,7 +47,7 @@ text_group_left.append(text_area_blue)
 text_group_left.append(text_area_white)
 splash.append(text_group_left)
 
-text_group_right = displayio.Group(max_size=10, scale=1, x=80, y=6)
+text_group_right = displayio.Group(scale=1, x=80, y=6)
 text_area_cyan = label.Label(terminalio.FONT, text="CYAN", color=0x00FFFF)
 text_group_right.append(text_area_cyan)
 text_area_magenta = label.Label(terminalio.FONT, text="\nMAGENTA", color=0xFF00FF)

--- a/examples/st7735r_128x160_simpletest.py
+++ b/examples/st7735r_128x160_simpletest.py
@@ -26,7 +26,7 @@ display_bus = displayio.FourWire(
 display = ST7735R(display_bus, width=160, height=128, rotation=90, bgr=True)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(160, 128, 1)
@@ -44,7 +44,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=5,
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=11, y=64)
+text_group = displayio.Group(scale=2, x=11, y=64)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7735r_minitft_featherwing_simpletest.py
+++ b/examples/st7735r_minitft_featherwing_simpletest.py
@@ -33,7 +33,7 @@ display = ST7735R(
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(160, 80, 1)
@@ -51,7 +51,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=5,
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=11, y=40)
+text_group = displayio.Group(scale=2, x=11, y=40)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7735r_minitft_simpletest.py
+++ b/examples/st7735r_minitft_simpletest.py
@@ -28,7 +28,7 @@ display = ST7735R(
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(160, 80, 1)
@@ -46,7 +46,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=5,
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=11, y=40)
+text_group = displayio.Group(scale=2, x=11, y=40)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7735r_simpletest.py
+++ b/examples/st7735r_simpletest.py
@@ -26,7 +26,7 @@ display_bus = displayio.FourWire(
 display = ST7735R(display_bus, width=128, height=128, colstart=2, rowstart=1)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(128, 128, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a ST7735R display to test with.