### PR TITLE
add type information

### DIFF
--- a/adafruit_st7735r.py
+++ b/adafruit_st7735r.py
@@ -33,6 +33,11 @@ Implementation Notes
   https://circuitpython.org/downloads
 
 """
+try:
+    # used for typing only
+    from typing import Any
+except ImportError:
+    pass
 
 import displayio
 
@@ -63,14 +68,26 @@ _INIT_SEQUENCE = bytearray(
     b"\x29\x80\x64"  # _DISPON
 )
 
+
 # pylint: disable=too-few-public-methods
 class ST7735R(displayio.Display):
-    """ST7735 driver for ST7735R"""
+    """
+    ST7735R display driver
 
-    def __init__(self, bus, *, bgr=False, invert=False, **kwargs):
-        """
-        :param bool bgr: (Optional) An extra init sequence to append (default=False)
-        """
+    :param displayio.FourWire bus: bus that the display is connected to
+    :param bool bgr: (Optional) An extra init sequence to append (default=False)
+    :param bool invert: (Optional) Invert the colors (default=False)
+    """
+
+    def __init__(
+        self,
+        bus: displayio.FourWire,
+        *,
+        bgr: bool = False,
+        invert: bool = False,
+        **kwargs: Any
+    ):
+
         init_sequence = _INIT_SEQUENCE
         if bgr:
             init_sequence += (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@ extensions = [
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
 # autodoc_mock_imports = ["digitalio", "busio"]
-autodoc_mock_imports = ["displayio"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),


### PR DESCRIPTION
resolves #26 

Type information has been added to the method signature and the docstrings. `displayio` was removed from the mocked modules in the sphinx config so that it will show the real signature instead of the mocked one. Same thing that was done on this PR: https://github.com/adafruit/Adafruit_CircuitPython_ILI9341/pull/29

tested successfully with PyGamer and slightly modified simpletest.