### PR TITLE
edge static on 1.44" 128x128 breakout TFT

### DIFF
--- a/examples/st7735r_simpletest.py
+++ b/examples/st7735r_simpletest.py
@@ -23,7 +23,7 @@ tft_dc = board.D6
 
 display_bus = FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=board.D9)
 
-display = ST7735R(display_bus, width=128, height=128, colstart=2, rowstart=1)
+display = ST7735R(display_bus, width=128, height=128, colstart=2, rowstart=3)
 
 # Make the display context
 splash = displayio.Group()


### PR DESCRIPTION
Small row shift to example st7735r_simpletest.py for the[ 1.44" 128x128 breakout TFT](https://www.adafruit.com/product/2088) . This removes the static edge that had been appearing.


![foo25](https://github.com/user-attachments/assets/c88fa6eb-66fb-413f-9ab8-db565cd6e78e)


[forum issue](https://forums.adafruit.com/viewtopic.php?t=222478) - credit to rob_cranfill





